### PR TITLE
feat: add ERC-20 token contract for voting

### DIFF
--- a/contracts/VotingToken.sol
+++ b/contracts/VotingToken.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract VotingToken is ERC20 {
+    string private _uri;
+
+    constructor(uint256 initialSupply, string memory uri) ERC20("VotingToken", "VOTE") {
+        _mint(msg.sender, initialSupply);
+        _uri = uri;
+    }
+
+    function getUri() external view returns (string memory) {
+        return _uri;
+    }
+}

--- a/contracts/VotingToken.sol
+++ b/contracts/VotingToken.sol
@@ -4,14 +4,9 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract VotingToken is ERC20 {
-    string private _uri;
 
-    constructor(uint256 initialSupply, string memory uri) ERC20("VotingToken", "VOTE") {
+    constructor(uint256 initialSupply) ERC20("VotingToken", "VOTE") {
         _mint(msg.sender, initialSupply);
-        _uri = uri;
     }
 
-    function getUri() external view returns (string memory) {
-        return _uri;
-    }
 }


### PR DESCRIPTION
1. Implemented the VotingToken.sol contract using OpenZeppelin's ERC-20 standard
2. Minted initial supply to the contract deployer